### PR TITLE
removed lines that were executed twice

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -272,13 +272,6 @@ class ST:
         selected = menu[selected].split('\t')[0]
         ST.conn = ST.connectionList[selected]
 
-        # clear list of identifiers in case connection is changed
-        ST.tables = []
-        ST.columns = []
-        ST.functions = []
-
-        ST.loadConnectionData(tablesCallback, columnsCallback, functionsCallback)
-
         ST.reset_cache(tablesCallback, columnsCallback, functionsCallback)
         _log('Connection {0} selected'.format(ST.conn))
 


### PR DESCRIPTION
removed some lines:

```python
        ST.tables = []
        ST.columns = []
        ST.functions = []

        ST.loadConnectionData(tablesCallback, columnsCallback, functionsCallback)
```

the following line has all these lines already:
```python
        ST.reset_cache(tablesCallback, columnsCallback, functionsCallback)
```

this fixes bug when results of query are doubled on first run.

related issue: https://github.com/Alexey-T/CudaText/issues/4713